### PR TITLE
fix: handle client disconnect properly with ignore_user_abort true

### DIFF
--- a/lib/Client.php
+++ b/lib/Client.php
@@ -301,8 +301,6 @@ class Client extends EventEmitter
      * Adds a CURL setting.
      *
      * These settings will be included in every HTTP request.
-     *
-     * @param mixed $value
      */
     public function addCurlSetting(int $name, $value): void
     {
@@ -340,7 +338,7 @@ class Client extends EventEmitter
      *
      * @var resource|null
      */
-    private $curlHandle = null;
+    private $curlHandle;
 
     /**
      * Handler for curl_multi requests.
@@ -349,7 +347,7 @@ class Client extends EventEmitter
      *
      * @var resource|null
      */
-    private $curlMultiHandle = null;
+    private $curlMultiHandle;
 
     /**
      * Has a list of curl handles, as well as their associated success and

--- a/lib/Message.php
+++ b/lib/Message.php
@@ -22,7 +22,7 @@ abstract class Message implements MessageInterface
      *
      * @var resource|string|callable|null
      */
-    protected $body = null;
+    protected $body;
 
     /**
      * Contains the list of HTTP headers.

--- a/lib/Response.php
+++ b/lib/Response.php
@@ -101,7 +101,7 @@ class Response extends Message implements ResponseInterface
      * @param array<string, mixed>|null     $headers
      * @param resource|string|callable|null $body
      */
-    public function __construct($status = 500, ?array $headers = null, $body = null)
+    public function __construct($status = 500, array $headers = null, $body = null)
     {
         if (null !== $status) {
             $this->setStatus($status);

--- a/lib/Sapi.php
+++ b/lib/Sapi.php
@@ -113,6 +113,12 @@ class Sapi
                     if ($copied <= 0) {
                         break;
                     }
+                    // Abort on client disconnect.
+                    // With ignore_user_abort(true), the script is not aborted on client disconnect.
+                    // To avoid reading the entire stream and dismissing the data afterward, check between the chunks if the client is still there.
+                    if (1 === ignore_user_abort() && 1 === connection_aborted()) {
+                        break;
+                    }
                     $left -= $copied;
                 }
             } else {

--- a/lib/functions.php
+++ b/lib/functions.php
@@ -168,9 +168,9 @@ function negotiateContentType(?string $acceptHeaderValue, array $availableOption
 
             // Does this entry win?
             if (
-                ($proposal['quality'] > $lastQuality) ||
-                ($proposal['quality'] === $lastQuality && $specificity > $lastSpecificity) ||
-                ($proposal['quality'] === $lastQuality && $specificity === $lastSpecificity && $optionIndex < $lastOptionIndex)
+                ($proposal['quality'] > $lastQuality)
+                || ($proposal['quality'] === $lastQuality && $specificity > $lastSpecificity)
+                || ($proposal['quality'] === $lastQuality && $specificity === $lastSpecificity && $optionIndex < $lastOptionIndex)
             ) {
                 $lastQuality = $proposal['quality'];
                 $lastSpecificity = $specificity;

--- a/phpstan.neon
+++ b/phpstan.neon
@@ -12,7 +12,7 @@ parameters:
     path: lib/Client.php
   -
     message: "#^Left side of || is always false.$#"
-    count: 1
+    count: 2
     path: lib/Client.php
   -
     message: "#^Strict comparison using === between null and array<string, mixed> will always evaluate to false.$#"

--- a/tests/HTTP/SapiTest.php
+++ b/tests/HTTP/SapiTest.php
@@ -300,4 +300,35 @@ class SapiTest extends \PHPUnit\Framework\TestCase
 
         self::assertEquals('foo', $result);
     }
+
+    public function testSendConnectionAborted(): void
+    {
+        $baseUrl = getenv('BASEURL');
+        if (!$baseUrl) {
+            $this->markTestSkipped('Set an environment value BASEURL to continue');
+        }
+
+        $url = rtrim($baseUrl, '/').'/connection_aborted.php';
+        $chunk_size = 4 * 1024 * 1024;
+        $fetch_size = 6 * 1024 * 1024;
+
+        $stream = fopen($url, 'r');
+        $size = 0;
+
+        while ($size <= $fetch_size) {
+            $temp = fread($stream, 8192);
+            if (false === $temp) {
+                break;
+            }
+            $size += strlen($temp);
+        }
+
+        fclose($stream);
+
+        sleep(5);
+
+        $bytes_read = file_get_contents(sys_get_temp_dir().'/dummy_stream_read_counter');
+        $this->assertEquals($chunk_size * 2, $bytes_read);
+        $this->assertGreaterThanOrEqual($fetch_size, $bytes_read);
+    }
 }

--- a/tests/www/connection_aborted.php
+++ b/tests/www/connection_aborted.php
@@ -17,7 +17,7 @@ class DummyStream
         return true;
     }
 
-    public function stream_read(int $count)
+    public function stream_read(int $count): string
     {
         $this->position += $count;
 

--- a/tests/www/connection_aborted.php
+++ b/tests/www/connection_aborted.php
@@ -1,0 +1,69 @@
+<?php
+
+declare(strict_types=1);
+
+use Sabre\HTTP;
+
+include '../bootstrap.php';
+
+class DummyStream
+{
+    private int $position;
+
+    public function stream_open(string $path, string $mode, int $options, ?string &$opened_path): bool
+    {
+        $this->position = 0;
+
+        return true;
+    }
+
+    public function stream_read(int $count)
+    {
+        $this->position += $count;
+
+        return random_bytes($count);
+    }
+
+    public function stream_tell(): int
+    {
+        return $this->position;
+    }
+
+    public function stream_eof(): bool
+    {
+        return $this->position > 25 * 1024 * 1024;
+    }
+
+    public function stream_close(): void
+    {
+        file_put_contents(sys_get_temp_dir().'/dummy_stream_read_counter', $this->position);
+    }
+}
+
+/*
+ * The DummyStream wrapper has two functions:
+ * - Provide dummy data.
+ * - Count how many bytes have been read.
+ */
+stream_wrapper_register('dummy', DummyStream::class);
+
+/*
+ * Overwrite default connection handling.
+ * The default behaviour is however for your script to be aborted when the remote client disconnects.
+ *
+ * Nextcloud/ownCloud set ignore_user_abort(true) on purpose to work around
+ * some edge cases where the default behavior would end a script too early.
+ *
+ * https://github.com/owncloud/core/issues/22370
+ * https://github.com/owncloud/core/pull/26775
+ */
+ignore_user_abort(true);
+
+$body = fopen('dummy://hello', 'r');
+
+$response = new HTTP\Response();
+$response->setStatus(200);
+$response->addHeader('Content-Length', 25 * 1024 * 1024);
+$response->setBody($body);
+
+HTTP\Sapi::sendResponse($response);


### PR DESCRIPTION
ignore_user_abort(true) instruct php to not abort the script on client disconnect. To avoid reading the entire stream and dismissing the data afterward, check between the chunks if the client is still there.